### PR TITLE
Fix hand removal bug when others play identical card

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -100,6 +100,7 @@ io.on("connection", (socket) => {
       const playedCard = game.playCard(playerId, cardIndex, targetPlayerId, guessCardId, io);
       logPlayerHands(game,roomId);
       io.to(roomId).emit("cardPlayed", {
+        playerId: playerId,
         player: game.players[playerId].name,
         card: playedCard,
         playedCards: game.playedCards,

--- a/frontend/src/Game.tsx
+++ b/frontend/src/Game.tsx
@@ -24,6 +24,13 @@ interface PlayerInfo {
   id: string;
 }
 
+interface CardPlayedData {
+  playerId: string;
+  player: string;
+  card: Card;
+  playedCards: PlayedCardEntry[];
+}
+
 const Game: React.FC<GameProps> = ({
   setScreen,
   roomId,
@@ -74,12 +81,14 @@ const Game: React.FC<GameProps> = ({
       setHand((prev) => [...prev, card]);
     });
 
-    socket.on("cardPlayed", (data) => {
+    socket.on("cardPlayed", (data: CardPlayedData) => {
       if (!data || !data.card) return;
       setPlayedCards(data.playedCards);
-      setHand((prev) =>
-        prev.filter((_, i) => i !== prev.findIndex((c) => c.id === data.card.id && c.name === data.card.name))
-      );
+      if (data.playerId === socket.id) {
+        setHand((prev) =>
+          prev.filter((_, i) => i !== prev.findIndex((c) => c.id === data.card.id && c.name === data.card.name))
+        );
+      }
     });
 
     socket.on("nextTurn", (data) => {


### PR DESCRIPTION
## Summary
- include the playerId in `cardPlayed` events from the server
- update the client to only remove a card from the hand when the event was triggered by the same player

## Testing
- `npm test` in `frontend` *(fails: react-scripts not found)*
- `npm test` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_6846f9d7a858832fb7eb71b1cb182515