### PR TITLE
Implement knight effect

### DIFF
--- a/backend/game/GameManager.js
+++ b/backend/game/GameManager.js
@@ -181,6 +181,43 @@ class GameManager {
           });
         }
         break;
+      case 3: // 騎士（knight）
+        if (
+          targetPlayerId &&
+          this.players[targetPlayerId] &&
+          !this.players[targetPlayerId].isEliminated &&
+          !this.players[targetPlayerId].isProtected
+        ) {
+          const myCard = player.hand[0];
+          const targetCard = this.players[targetPlayerId].hand[0];
+          if (myCard && targetCard) {
+            if (myCard.id === targetCard.id) {
+              console.log("騎士の効果: 引き分けでした。");
+            } else if (myCard.id < targetCard.id) {
+              player.isEliminated = true;
+              console.log(`${player.name} は脱落しました！（騎士の効果）`);
+              io.to(this.roomId).emit("playerEliminated", {
+                playerId: playerId,
+                name: player.name,
+              });
+            } else {
+              this.players[targetPlayerId].isEliminated = true;
+              console.log(`${this.players[targetPlayerId].name} は脱落しました！（騎士の効果）`);
+              io.to(this.roomId).emit("playerEliminated", {
+                playerId: targetPlayerId,
+                name: this.players[targetPlayerId].name,
+              });
+            }
+
+            const alive = Object.values(this.players).filter((p) => !p.isEliminated);
+            if (alive.length === 1) {
+              io.to(this.roomId).emit("gameEnded", {
+                winner: alive[0].name,
+              });
+            }
+          }
+        }
+        break;
 
       // TODO: 他のカード（道化、騎士、僧侶、魔術師、将軍、大臣、姫）の処理を追加
       default:

--- a/frontend/src/Game.tsx
+++ b/frontend/src/Game.tsx
@@ -167,8 +167,8 @@ const Game: React.FC<GameProps> = ({
   // カードを出す
   const handlePlay = (index: number) => {
     const card = hand[index];
-    if (card.id === 2) {
-      // 道化カードはターゲット選択のみ
+    if (card.id === 2 || card.id === 3) {
+      // 道化・騎士カードはターゲット選択のみ
       setSelectCardIndex(index);
       setShowTargetModal(true);
       return;
@@ -261,11 +261,11 @@ const Game: React.FC<GameProps> = ({
         ))}
       </div>
 
-      {/* ターゲット選択モーダル（道化用） */}
+      {/* ターゲット選択モーダル（道化・騎士用） */}
       {showTargetModal && (
         <div className="fixed z-10 left-0 top-0 w-full h-full bg-black bg-opacity-30 flex items-center justify-center">
           <div className="bg-white p-4 rounded shadow">
-            <h3 className="mb-2">見る相手を選んでください</h3>
+            <h3 className="mb-2">相手を選んでください</h3>
             <ul>
               {otherPlayers.map((p) => (
                 <li key={p.id} className="mb-2">


### PR DESCRIPTION
## Summary
- enable `knight` card effect in backend
- allow choosing a target when playing a knight card
- update target selection modal wording

## Testing
- `npm test --prefix frontend --silent` *(fails: react-scripts not found)*
- `npm test --prefix backend --silent`

------
https://chatgpt.com/codex/tasks/task_e_684982f2a1a4832fa848a3137c213842