### PR TITLE
Add minister elimination effect

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -83,6 +83,7 @@ io.on("connection", (socket) => {
       if (drawnCard) {
         logPlayerHands(game);
         socket.emit("cardDrawn", drawnCard);
+        game.checkMinisterElimination(playerId, io);
       }
     }
   });


### PR DESCRIPTION
## Summary
- add minister card elimination rule when hand total exceeds 12
- apply elimination check after drawing or hand changes

## Testing
- `npm test` in backend *(fails: Error: no test specified)*
- `npm test --silent` in frontend *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684995000f40832f93c342b30f09eaaa