### PR TITLE
Fix minister elimination turn bug

### DIFF
--- a/backend/game/GameManager.js
+++ b/backend/game/GameManager.js
@@ -24,10 +24,10 @@ class GameManager {
 
   checkMinisterElimination(playerId, io) {
     const player = this.players[playerId];
-    if (!player || player.isEliminated) return;
+    if (!player || player.isEliminated) return false;
 
     const hasMinister = player.hand.some((c) => c.id === 7);
-    if (!hasMinister) return;
+    if (!hasMinister) return false;
 
     const total = player.hand.reduce((sum, c) => sum + c.id, 0);
     if (total > 12) {
@@ -44,7 +44,9 @@ class GameManager {
       if (alive.length === 1 && io) {
         io.to(this.roomId).emit("gameEnded", { winner: alive[0].name });
       }
+      return true;
     }
+    return false;
   }
 
   checkPrincessElimination(playerId, discardedCard, io) {

--- a/backend/index.js
+++ b/backend/index.js
@@ -83,7 +83,17 @@ io.on("connection", (socket) => {
       if (drawnCard) {
         logPlayerHands(game);
         socket.emit("cardDrawn", drawnCard);
-        game.checkMinisterElimination(playerId, io);
+        const eliminated = game.checkMinisterElimination(playerId, io);
+        if (eliminated) {
+          const alive = Object.values(game.players).filter((p) => !p.isEliminated);
+          if (alive.length > 1) {
+            game.nextTurn();
+            const currentPlayerId = game.getCurrentPlayerId();
+            io.to(roomId).emit("nextTurn", {
+              currentPlayer: game.players[currentPlayerId].name,
+            });
+          }
+        }
       }
     }
   });


### PR DESCRIPTION
## Summary
- return boolean from `checkMinisterElimination`
- when minister elimination occurs on a draw, automatically advance to the next turn

## Testing
- `npm test` (backend)
- `npm test` (frontend) *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849ab07f1cc832f89d573198286acf6