### PR TITLE
Implement deck exhaustion win condition

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -79,7 +79,7 @@ io.on("connection", (socket) => {
       socket.emit("errorMessage", "今はあなたのターンではありません。");
       return;
       }
-      const drawnCard = game.drawCard(playerId);
+      const drawnCard = game.drawCard(playerId, io);
       if (drawnCard) {
         logPlayerHands(game);
         socket.emit("cardDrawn", drawnCard);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -29,7 +29,11 @@ const App: React.FC = () => {
       )}
       {screen === "result" && (
         <div className="max-w-md mx-auto bg-white p-4 rounded shadow">
-          <h1 className="text-2xl mb-4">勝者: {winner} さん！</h1>
+          {winner === "引き分け" ? (
+            <h1 className="text-2xl mb-4">引き分けでした！</h1>
+          ) : (
+            <h1 className="text-2xl mb-4">勝者: {winner} さん！</h1>
+          )}
           <button
             onClick={() => setScreen("lobby")}
             className="bg-blue-500 text-white px-4 py-2 rounded w-full"


### PR DESCRIPTION
## Summary
- handle empty deck in `GameManager.drawCard`
- determine winner by hand cost with new method `determineWinnerByHandCost`
- pass socket io to `drawCard` in server
- show draw result on the frontend

## Testing
- `npm test` in `backend` *(fails: no test specified)*
- `npm test` in `frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849c2b84ce8832f86493093d2fdb9a9