### PR TITLE
Implement Princess Glasses revival card

### DIFF
--- a/backend/game/GameManager.js
+++ b/backend/game/GameManager.js
@@ -101,6 +101,7 @@ class GameManager {
         playerId: playerId,
         name: player.name,
       });
+      io.to(this.roomId).emit("deckCount", { deckCount: this.deck.length });
     }
     this.checkMinisterElimination(playerId, io);
     return true;

--- a/backend/game/GameManager.js
+++ b/backend/game/GameManager.js
@@ -82,13 +82,18 @@ class GameManager {
   checkPrincessGlassesRevival(playerId, io) {
     const player = this.players[playerId];
     if (!player || !player.isEliminated) return false;
-    const hasCard = player.hand.some((c) => c.id === 9);
-    if (!hasCard) return false;
+    const cardIndex = player.hand.findIndex((c) => c.id === 9);
+    if (cardIndex === -1) return false;
     if (!this.deck.length) return false;
 
-    player.isEliminated = false;
+    const discarded = player.hand.splice(cardIndex, 1)[0];
+    this.playedCards.push({ player: player.name, card: discarded });
+
     const newCard = this.deck.pop();
+
     player.hand.push(newCard);
+    player.isEliminated = false;
+
     console.log(`${player.name} は姫(眼鏡)の効果で復活しました。`);
     if (io) {
       io.to(playerId).emit("cardDrawn", newCard);

--- a/backend/game/GameManager.js
+++ b/backend/game/GameManager.js
@@ -88,6 +88,14 @@ class GameManager {
 
     const discarded = player.hand.splice(cardIndex, 1)[0];
     this.playedCards.push({ player: player.name, card: discarded });
+    if (io) {
+      io.to(this.roomId).emit("cardPlayed", {
+        playerId: playerId,
+        player: player.name,
+        card: discarded,
+        playedCards: this.playedCards,
+      });
+    }
 
     const newCard = this.deck.pop();
 

--- a/backend/game/GameManager.js
+++ b/backend/game/GameManager.js
@@ -37,15 +37,15 @@ class GameManager {
       player.hasDrawnCard = false;
       console.log(`${player.name} は大臣の効果で脱落しました。`);
 
+      if (io) {
+        io.to(this.roomId).emit("playerEliminated", {
+          playerId: playerId,
+          name: player.name,
+        });
+      }
+
       const revived = this.checkPrincessGlassesRevival(playerId, io);
       if (!revived) {
-        if (io) {
-          io.to(this.roomId).emit("playerEliminated", {
-            playerId: playerId,
-            name: player.name,
-          });
-        }
-
         const alive = Object.values(this.players).filter((p) => !p.isEliminated);
         if (alive.length === 1 && io) {
           io.to(this.roomId).emit("gameEnded", { winner: alive[0].name });

--- a/backend/game/GameManager.js
+++ b/backend/game/GameManager.js
@@ -9,7 +9,7 @@ const CARD_LIST = [
   { id: 6, name: "将軍", enName: "general", cost: 6, count: 1 },
   { id: 7, name: "大臣", enName: "minister", cost: 7, count: 1 },
   { id: 8, name: "姫", enName: "princess", cost: 8, count: 1 },
-  { id: 9, name: "姫(眼鏡)", enName: "princess_glasses", cost: 9, count: 1 },
+  { id: 9, name: "姫(眼鏡)", enName: "princess_glasses", cost: 8, count: 1 },
 ];
 
 class GameManager {
@@ -283,7 +283,7 @@ class GameManager {
           });
         }
         break;
-      case 3: // 騎士（knight）Add commentMore actions
+      case 3: // 騎士（knight）
         if (
           targetPlayerId &&
           this.players[targetPlayerId] &&

--- a/frontend/src/Game.tsx
+++ b/frontend/src/Game.tsx
@@ -69,6 +69,7 @@ const Game: React.FC<GameProps> = ({
     { id: 6, name: "将軍", enName: "general", cost: 5 },
     { id: 7, name: "大臣", enName: "minister", cost: 6 },
     { id: 8, name: "姫", enName: "princess", cost: 7 },
+    { id: 9, name: "姫(眼鏡)", enName: "princess_glasses", cost: 8 },
   ];
 
   // 手札を見るモーダル
@@ -159,6 +160,16 @@ const Game: React.FC<GameProps> = ({
       setTimeout(() => setErrorMessage(""), 3000);
     });
 
+    socket.on("playerRevived", ({ playerId, name }) => {
+      setPlayers((prev) =>
+        prev.map((p) =>
+          p.id === playerId ? { ...p, isEliminated: false } : p
+        )
+      );
+      setErrorMessage(`${name} さんが復活しました`);
+      setTimeout(() => setErrorMessage(""), 3000);
+    });
+
     socket.on("gameEnded", ({ winner }) => {
       setWinner(winner);
       setScreen("result");
@@ -180,6 +191,7 @@ const Game: React.FC<GameProps> = ({
       socket.off("seeHand");
       socket.off("deckCount");
       socket.off("playerEliminated");
+      socket.off("playerRevived");
       socket.off("gameEnded");
       socket.off("errorMessage");
     };


### PR DESCRIPTION
## Summary
- add new card "姫(眼鏡)" to card list
- implement revival ability in GameManager
- support revival event in frontend
- extend soldier guess options with the new card

## Testing
- `npm test --silent --yes` *(fails: `react-scripts: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6857e109feb0832fa7a5c789dc458fcf