### PR TITLE
feat: add test setup API

### DIFF
--- a/backend/game/GameManager.js
+++ b/backend/game/GameManager.js
@@ -532,3 +532,4 @@ class GameManager {
 }
 
 module.exports = GameManager;
+module.exports.CARD_LIST = CARD_LIST;


### PR DESCRIPTION
## Summary
- add /test/setup endpoint to modify deck order and player hands for tests
- export CARD_LIST from GameManager for API

## Testing
- `npm test`
- `npx playwright test` *(fails: missing browsers, attempted install returns 403)*

------
https://chatgpt.com/codex/tasks/task_e_6890cbb84d10832fa0b166ea7557899b