### PR TITLE
feat: display card images on game screen

### DIFF
--- a/frontend/public/cards/clown.svg
+++ b/frontend/public/cards/clown.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='300' viewBox='0 0 200 300'>
+  <rect width='200' height='300' fill='#f8f8f8' stroke='#000'/>
+  <text x='100' y='150' font-size='24' text-anchor='middle' dominant-baseline='middle' fill='#000'>道化</text>
+</svg>

--- a/frontend/public/cards/countess.svg
+++ b/frontend/public/cards/countess.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='300' viewBox='0 0 200 300'>
+  <rect width='200' height='300' fill='#f8f8f8' stroke='#000'/>
+  <text x='100' y='150' font-size='24' text-anchor='middle' dominant-baseline='middle' fill='#000'>伯爵夫人</text>
+</svg>

--- a/frontend/public/cards/general.svg
+++ b/frontend/public/cards/general.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='300' viewBox='0 0 200 300'>
+  <rect width='200' height='300' fill='#f8f8f8' stroke='#000'/>
+  <text x='100' y='150' font-size='24' text-anchor='middle' dominant-baseline='middle' fill='#000'>将軍</text>
+</svg>

--- a/frontend/public/cards/knight.svg
+++ b/frontend/public/cards/knight.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='300' viewBox='0 0 200 300'>
+  <rect width='200' height='300' fill='#f8f8f8' stroke='#000'/>
+  <text x='100' y='150' font-size='24' text-anchor='middle' dominant-baseline='middle' fill='#000'>騎士</text>
+</svg>

--- a/frontend/public/cards/marchioness.svg
+++ b/frontend/public/cards/marchioness.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='300' viewBox='0 0 200 300'>
+  <rect width='200' height='300' fill='#f8f8f8' stroke='#000'/>
+  <text x='100' y='150' font-size='24' text-anchor='middle' dominant-baseline='middle' fill='#000'>女侯爵</text>
+</svg>

--- a/frontend/public/cards/minister.svg
+++ b/frontend/public/cards/minister.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='300' viewBox='0 0 200 300'>
+  <rect width='200' height='300' fill='#f8f8f8' stroke='#000'/>
+  <text x='100' y='150' font-size='24' text-anchor='middle' dominant-baseline='middle' fill='#000'>大臣</text>
+</svg>

--- a/frontend/public/cards/monk.svg
+++ b/frontend/public/cards/monk.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='300' viewBox='0 0 200 300'>
+  <rect width='200' height='300' fill='#f8f8f8' stroke='#000'/>
+  <text x='100' y='150' font-size='24' text-anchor='middle' dominant-baseline='middle' fill='#000'>僧侶</text>
+</svg>

--- a/frontend/public/cards/princess.svg
+++ b/frontend/public/cards/princess.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='300' viewBox='0 0 200 300'>
+  <rect width='200' height='300' fill='#f8f8f8' stroke='#000'/>
+  <text x='100' y='150' font-size='24' text-anchor='middle' dominant-baseline='middle' fill='#000'>姫</text>
+</svg>

--- a/frontend/public/cards/princess_bomb.svg
+++ b/frontend/public/cards/princess_bomb.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='300' viewBox='0 0 200 300'>
+  <rect width='200' height='300' fill='#f8f8f8' stroke='#000'/>
+  <text x='100' y='150' font-size='24' text-anchor='middle' dominant-baseline='middle' fill='#000'>姫(爆弾)</text>
+</svg>

--- a/frontend/public/cards/princess_glasses.svg
+++ b/frontend/public/cards/princess_glasses.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='300' viewBox='0 0 200 300'>
+  <rect width='200' height='300' fill='#f8f8f8' stroke='#000'/>
+  <text x='100' y='150' font-size='24' text-anchor='middle' dominant-baseline='middle' fill='#000'>姫(眼鏡)</text>
+</svg>

--- a/frontend/public/cards/soldier.svg
+++ b/frontend/public/cards/soldier.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='300' viewBox='0 0 200 300'>
+  <rect width='200' height='300' fill='#f8f8f8' stroke='#000'/>
+  <text x='100' y='150' font-size='24' text-anchor='middle' dominant-baseline='middle' fill='#000'>兵士</text>
+</svg>

--- a/frontend/public/cards/sorcerer.svg
+++ b/frontend/public/cards/sorcerer.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='300' viewBox='0 0 200 300'>
+  <rect width='200' height='300' fill='#f8f8f8' stroke='#000'/>
+  <text x='100' y='150' font-size='24' text-anchor='middle' dominant-baseline='middle' fill='#000'>魔術師</text>
+</svg>

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import App from './App';
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import App from "./App";
 
-test('renders learn react link', () => {
+test("renders lobby title", () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByText(/Love Letter - ロビー/i);
+  expect(heading).toBeInTheDocument();
 });

--- a/frontend/src/Game.tsx
+++ b/frontend/src/Game.tsx
@@ -333,20 +333,25 @@ const Game: React.FC<GameProps> = ({
 
       {/* 手札表示 */}
       <div className="grid grid-cols-2 gap-2 mb-4">
-        {hand.map((card, index) => (
-          <button
-            key={index}
-            onClick={() => handlePlay(index)}
-            disabled={playerName !== currentPlayer || hand.length < 2}
-            className={`bg-pink-500 text-white px-4 py-2 rounded ${
-              playerName !== currentPlayer || hand.length < 2
-                ? "opacity-50 cursor-not-allowed"
-                : ""
-            }`}
-          >
-            {card.name}
-          </button>
-        ))}
+        {hand.map((card, index) => {
+          const disabled = playerName !== currentPlayer || hand.length < 2;
+          return (
+            <button
+              key={index}
+              onClick={() => handlePlay(index)}
+              disabled={disabled}
+              className={`rounded overflow-hidden ${
+                disabled ? "opacity-50 cursor-not-allowed" : ""
+              }`}
+            >
+              <img
+                src={`/cards/${card.enName}.svg`}
+                alt={card.name}
+                className="w-full h-auto"
+              />
+            </button>
+          );
+        })}
       </div>
 
       {/* ターゲット選択モーダル（道化・騎士用） */}
@@ -405,7 +410,7 @@ const Game: React.FC<GameProps> = ({
               <ul>
                 {CARD_OPTIONS.map((c) => (
                   <li key={c.id} className="mb-1">
-                    <label>
+                    <label className="flex items-center gap-2">
                       <input
                         type="radio"
                         name="guessCard"
@@ -413,7 +418,12 @@ const Game: React.FC<GameProps> = ({
                         onChange={() => setGuessCardId(c.id)}
                         className="mr-1"
                       />
-                      {c.name}
+                      <img
+                        src={`/cards/${c.enName}.svg`}
+                        alt={c.name}
+                        className="w-8 h-auto"
+                      />
+                      <span>{c.name}</span>
                     </label>
                   </li>
                 ))}
@@ -479,9 +489,16 @@ const Game: React.FC<GameProps> = ({
         <div className="fixed z-20 left-0 top-0 w-full h-full bg-black bg-opacity-40 flex items-center justify-center">
           <div className="bg-white p-6 rounded shadow text-center">
             <h3 className="mb-4 text-lg font-bold">手札を見る</h3>
-            <p className="mb-4">
+            <p className="mb-2">
               <span className="font-bold">{seeHandInfo.targetName}</span>
               さんの手札は
+            </p>
+            <img
+              src={`/cards/${seeHandInfo.card.enName}.svg`}
+              alt={seeHandInfo.card.name}
+              className="w-32 h-auto mx-auto mb-2"
+            />
+            <p className="mb-4">
               <span className="text-pink-500 font-bold">「{seeHandInfo.card.name}」</span>
               です
             </p>
@@ -499,8 +516,13 @@ const Game: React.FC<GameProps> = ({
         <h3 className="text-md font-bold mb-2">場に出たカード履歴</h3>
         <ul className="list-disc list-inside">
           {playedCards.map((entry, index) => (
-            <li key={index}>
-              {entry.player} さん: {entry.card.name}
+            <li key={index} className="flex items-center gap-2">
+              <span>{entry.player} さん:</span>
+              <img
+                src={`/cards/${entry.card.enName}.svg`}
+                alt={entry.card.name}
+                className="w-12 h-auto"
+              />
             </li>
           ))}
         </ul>


### PR DESCRIPTION
## Summary
- render card images in player hand, modals, and history
- add placeholder SVG assets for each card
- adjust lobby title test

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689f4ac33fa4832fb5a7173b7d79b4a9