### PR TITLE
refactor: modularize game manager utilities

### DIFF
--- a/backend/game/GameManager.js
+++ b/backend/game/GameManager.js
@@ -1,19 +1,7 @@
 // backend/game/GameManager.js
 
-const CARD_LIST = [
-  { id: 1, name: "兵士", enName: "soldier", cost: 1, count: 5 },
-  { id: 2, name: "道化", enName: "clown", cost: 2, count: 2 },
-  { id: 3, name: "騎士", enName: "knight", cost: 3, count: 2 },
-  { id: 4, name: "僧侶", enName: "monk", cost: 4, count: 2 },
-  { id: 5, name: "魔術師", enName: "sorcerer", cost: 5, count: 2 },
-  { id: 6, name: "将軍", enName: "general", cost: 6, count: 1 },
-  { id: 7, name: "大臣", enName: "minister", cost: 7, count: 1 },
-  { id: 8, name: "姫", enName: "princess", cost: 8, count: 1 },
-  { id: 9, name: "姫(眼鏡)", enName: "princess_glasses", cost: 8, count: 1 },
-  { id: 10, name: "伯爵夫人", enName: "countess", cost: 8, count: 1 },
-  { id: 11, name: "女侯爵", enName: "marchioness", cost: 7, count: 1 },
-  { id: 12, name: "姫(爆弾)", enName: "princess_bomb", cost: 8, count: 1 },
-];
+const CARD_LIST = require("./cards");
+const effects = require("./effects");
 
 class GameManager {
   constructor(roomId) {
@@ -26,147 +14,18 @@ class GameManager {
     this.gameStarted = false;
   }
 
-  // Return true if the player is eliminated by the minister effect
-  checkMinisterElimination(playerId, io) {
-    const player = this.players[playerId];
-    if (!player || player.isEliminated) return false;
-
-    const ministerIndex = player.hand.findIndex((c) => c.id === 7);
-    if (ministerIndex === -1) return false;
-
-    const total = player.hand.reduce((sum, c) => sum + c.cost, 0);
-    if (total >= 12) {
-      player.isEliminated = true;
-      player.hasDrawnCard = false;
-      console.log(`${player.name} は大臣の効果で脱落しました。`);
-
-      if (io) {
-        io.to(this.roomId).emit("playerEliminated", {
-          playerId: playerId,
-          name: player.name,
-        });
-      }
-
-      // 大臣のカードを捨て札に移動
-      const ministerCard = player.hand.splice(ministerIndex, 1)[0];
-      this.playedCards.push({ player: player.name, card: ministerCard });
-      if (io) {
-        io.to(this.roomId).emit("cardPlayed", {
-          playerId: playerId,
-          player: player.name,
-          card: ministerCard,
-          playedCards: this.playedCards,
-        });
-      }
-
-      const revived = this.checkPrincessGlassesRevival(playerId, io);
-
-      if (!revived) {
-        // 脱落したままなら残りの手札も捨て札へ
-        while (player.hand.length) {
-          const discarded = player.hand.pop();
-          this.playedCards.push({ player: player.name, card: discarded });
-          if (io) {
-            io.to(this.roomId).emit("cardPlayed", {
-              playerId: playerId,
-              player: player.name,
-              card: discarded,
-              playedCards: this.playedCards,
-            });
-          }
-        }
-
-        const alive = Object.values(this.players).filter((p) => !p.isEliminated);
-        if (alive.length === 1 && io) {
-          io.to(this.roomId).emit("gameEnded", { winner: alive[0].name });
-        }
-      }
-
-      return true;
-    }
-    return false;
+  emitToRoom(io, event, data) {
+    if (io) io.to(this.roomId).emit(event, data);
   }
 
-  checkPrincessElimination(playerId, discardedCard, io) {
-    const player = this.players[playerId];
-    if (!player || player.isEliminated) return;
-
-    if (discardedCard && discardedCard.id === 8) {
-      player.isEliminated = true;
-      console.log(`${player.name} は姫を捨てたため脱落しました。`);
-      const revived = this.checkPrincessGlassesRevival(playerId, io);
-      if (!revived) {
-        if (io) {
-          io.to(this.roomId).emit("playerEliminated", {
-            playerId: playerId,
-            name: player.name,
-          });
-        }
-        const alive = Object.values(this.players).filter((p) => !p.isEliminated);
-        if (alive.length === 1 && io) {
-          io.to(this.roomId).emit("gameEnded", { winner: alive[0].name });
-        }
-      }
-    }
+  emitToPlayer(io, playerId, event, data) {
+    if (io) io.to(playerId).emit(event, data);
   }
 
-  checkPrincessGlassesRevival(playerId, io) {
-    const player = this.players[playerId];
-    if (!player || !player.isEliminated) return false;
-    const cardIndex = player.hand.findIndex((c) => c.id === 9);
-    if (cardIndex === -1) return false;
-    if (!this.deck.length) return false;
-
-    const discarded = player.hand.splice(cardIndex, 1)[0];
-    this.playedCards.push({ player: player.name, card: discarded });
-    if (io) {
-      io.to(this.roomId).emit("cardPlayed", {
-        playerId: playerId,
-        player: player.name,
-        card: discarded,
-        playedCards: this.playedCards,
-      });
-    }
-
-    const newCard = this.deck.pop();
-
-    player.hand.push(newCard);
-    if (this.deck.length === 0) {
-      this.handleCountessElimination(io);
-    }
-    player.isEliminated = false;
-
-    console.log(`${player.name} は姫(眼鏡)の効果で復活しました。`);
-    if (io) {
-      io.to(playerId).emit("cardDrawn", newCard);
-      io.to(this.roomId).emit("playerRevived", {
-        playerId: playerId,
-        name: player.name,
-      });
-      io.to(this.roomId).emit("deckCount", { deckCount: this.deck.length });
-    }
-    return true;
+  getAlivePlayers() {
+    return Object.values(this.players).filter((p) => !p.isEliminated);
   }
 
-  handleCountessElimination(io) {
-    Object.keys(this.players).forEach((pid) => {
-      const p = this.players[pid];
-      if (!p.isEliminated && p.hand.some((c) => c.id === 10)) {
-        p.isEliminated = true;
-        console.log(`${p.name} は伯爵夫人を持ったまま山札が尽きたため脱落しました。`);
-        const revived = this.checkPrincessGlassesRevival(pid, io);
-        if (!revived && io) {
-          io.to(this.roomId).emit("playerEliminated", { playerId: pid, name: p.name });
-        }
-      }
-    });
-    const alive = Object.values(this.players).filter((p) => !p.isEliminated);
-    if (alive.length === 1 && io) {
-      io.to(this.roomId).emit("gameEnded", { winner: alive[0].name });
-    } else if (io) {
-      this.determineWinnerByHandCost(io);
-    }
-  }
 
   addPlayer(socketId, name) {
     if (Object.keys(this.players).length >= 5) return false;
@@ -277,19 +136,17 @@ class GameManager {
       console.log(
         `${player.name} は手札の合計コストが12以上のため女侯爵を出さなければなりません。`
       );
-      if (io) {
-        io.to(playerId).emit(
-          "errorMessage",
-          "手札のコスト合計が12以上のため、女侯爵を出さなければなりません。"
-        );
-      }
+      this.emitToPlayer(
+        io,
+        playerId,
+        "errorMessage",
+        "手札のコスト合計が12以上のため、女侯爵を出さなければなりません。"
+      );
       return null;
     }
     if (selectedCard.id === 10) {
       console.log(`${player.name} は伯爵夫人を出すことはできません。`);
-      if (io) {
-        io.to(playerId).emit("errorMessage", "伯爵夫人は場に出せません。");
-      }
+      this.emitToPlayer(io, playerId, "errorMessage", "伯爵夫人は場に出せません。");
       return null;
     }
 
@@ -321,25 +178,23 @@ class GameManager {
         ) {
           const targetHand = this.players[targetPlayerId].hand[0];
           if (targetHand.id === guessCardId) {
-            this.players[targetPlayerId].isEliminated = true;
-            console.log(
-              `${this.players[targetPlayerId].name} は脱落しました！（兵士の効果）`
-            );
-            const revived = this.checkPrincessGlassesRevival(targetPlayerId, io);
-            if (!revived) {
-              io.to(this.roomId).emit("playerEliminated", {
-                playerId: targetPlayerId,
-                name: this.players[targetPlayerId].name,
-              });
-              const alive = Object.values(this.players).filter(
-                (p) => !p.isEliminated
+              this.players[targetPlayerId].isEliminated = true;
+              console.log(
+                `${this.players[targetPlayerId].name} は脱落しました！（兵士の効果）`
               );
-              if (alive.length === 1) {
-                io.to(this.roomId).emit("gameEnded", {
-                  winner: alive[0].name,
+              const revived = this.checkPrincessGlassesRevival(targetPlayerId, io);
+              if (!revived) {
+                this.emitToRoom(io, "playerEliminated", {
+                  playerId: targetPlayerId,
+                  name: this.players[targetPlayerId].name,
                 });
+                const alive = this.getAlivePlayers();
+                if (alive.length === 1) {
+                  this.emitToRoom(io, "gameEnded", {
+                    winner: alive[0].name,
+                  });
+                }
               }
-            }
           } else {
             console.log(`${this.players[targetPlayerId].name} はセーフでした。`);
           }
@@ -362,11 +217,15 @@ class GameManager {
         ) {
           const targetHand = this.players[targetPlayerId].hand[0];
           // io経由で直接プレイヤーに送る。playerIdはsocket.id
-          console.log(`[seeHand emit] to ${playerId} :`, this.players[targetPlayerId].name, targetHand);
-          io.to(playerId).emit("seeHand", {
-            targetName: this.players[targetPlayerId].name,
-            card: targetHand,
-          });
+            console.log(
+              `[seeHand emit] to ${playerId} :`,
+              this.players[targetPlayerId].name,
+              targetHand
+            );
+            this.emitToPlayer(io, playerId, "seeHand", {
+              targetName: this.players[targetPlayerId].name,
+              card: targetHand,
+            });
         }
         break;
       case 3: // 騎士（knight）
@@ -396,7 +255,7 @@ class GameManager {
               console.log(`${player.name} は脱落しました！（騎士の効果）`);
               const revived = this.checkPrincessGlassesRevival(playerId, io);
               if (!revived) {
-                io.to(this.roomId).emit("playerEliminated", {
+                this.emitToRoom(io, "playerEliminated", {
                   playerId: playerId,
                   name: player.name,
                 });
@@ -406,19 +265,19 @@ class GameManager {
               console.log(`${this.players[targetPlayerId].name} は脱落しました！（騎士の効果）`);
               const revived = this.checkPrincessGlassesRevival(targetPlayerId, io);
               if (!revived) {
-                io.to(this.roomId).emit("playerEliminated", {
+                this.emitToRoom(io, "playerEliminated", {
                   playerId: targetPlayerId,
                   name: this.players[targetPlayerId].name,
                 });
               }
             }
 
-            const alive = Object.values(this.players).filter((p) => !p.isEliminated);
-            if (alive.length === 1) {
-              io.to(this.roomId).emit("gameEnded", {
-                winner: alive[0].name,
-              });
-            }
+              const alive = this.getAlivePlayers();
+              if (alive.length === 1) {
+                this.emitToRoom(io, "gameEnded", {
+                  winner: alive[0].name,
+                });
+              }
           }
         }
         break;
@@ -449,23 +308,23 @@ class GameManager {
               );
               break;
             }
-            const discarded = this.players[targetId].hand.splice(0, 1)[0];
-            if (discarded) {
-              this.playedCards.push({
-                player: this.players[targetId].name,
-                card: discarded,
-              });
-              this.checkPrincessElimination(targetId, discarded, io);
-            }
-            if (this.deck.length) {
-              const newCard = this.deck.pop();
-              this.players[targetId].hand = [newCard];
-              io.to(targetId).emit("replaceCard", newCard);
-              this.checkMinisterElimination(targetId, io);
-              if (this.deck.length === 0) {
-                this.handleCountessElimination(io);
+              const discarded = this.players[targetId].hand.splice(0, 1)[0];
+              if (discarded) {
+                this.playedCards.push({
+                  player: this.players[targetId].name,
+                  card: discarded,
+                });
+                this.checkPrincessElimination(targetId, discarded, io);
               }
-            }
+              if (this.deck.length) {
+                const newCard = this.deck.pop();
+                this.players[targetId].hand = [newCard];
+                this.emitToPlayer(io, targetId, "replaceCard", newCard);
+                this.checkMinisterElimination(targetId, io);
+                if (this.deck.length === 0) {
+                  this.handleCountessElimination(io);
+                }
+              }
           }
         }
         break;
@@ -488,15 +347,17 @@ class GameManager {
           const targetHand = [...this.players[targetPlayerId].hand];
           player.hand = targetHand;
           this.players[targetPlayerId].hand = myHand;
-          if (player.hand[0]) {
-            io.to(playerId).emit("replaceCard", player.hand[0]);
-          }
-          if (this.players[targetPlayerId].hand[0]) {
-            io.to(targetPlayerId).emit(
-              "replaceCard",
-              this.players[targetPlayerId].hand[0]
-            );
-          }
+            if (player.hand[0]) {
+              this.emitToPlayer(io, playerId, "replaceCard", player.hand[0]);
+            }
+            if (this.players[targetPlayerId].hand[0]) {
+              this.emitToPlayer(
+                io,
+                targetPlayerId,
+                "replaceCard",
+                this.players[targetPlayerId].hand[0]
+              );
+            }
           this.checkMinisterElimination(playerId, io);
           this.checkMinisterElimination(targetPlayerId, io);
         }
@@ -515,18 +376,16 @@ class GameManager {
         break;
       case 12: // 姫(爆弾)
         player.isEliminated = true;
-        if (io) {
-          io.to(this.roomId).emit("playerEliminated", {
-            playerId: playerId,
-            name: player.name,
-          });
-          const alive = Object.values(this.players).filter((p) => !p.isEliminated);
-          if (alive.length <= 1) {
-            const winner = alive.length === 1 ? alive[0].name : "引き分け";
-            io.to(this.roomId).emit("gameEnded", { winner });
-          } else {
-            this.determineWinnerByHandCost(io);
-          }
+        this.emitToRoom(io, "playerEliminated", {
+          playerId: playerId,
+          name: player.name,
+        });
+        const alive = this.getAlivePlayers();
+        if (alive.length <= 1) {
+          const winner = alive.length === 1 ? alive[0].name : "引き分け";
+          this.emitToRoom(io, "gameEnded", { winner });
+        } else {
+          this.determineWinnerByHandCost(io);
         }
         break;
       // TODO: 他のカード（道化、騎士、僧侶、魔術師、将軍、大臣、姫）の処理を追加
@@ -537,25 +396,6 @@ class GameManager {
     return card;
   }
 
-  determineWinnerByHandCost(io) {
-    const alive = Object.values(this.players).filter((p) => !p.isEliminated);
-    if (alive.length === 0) return;
-
-    const costs = alive.map((p) => {
-      const maxCost = p.hand.reduce((max, c) => (c.cost > max ? c.cost : max), 0);
-      return { name: p.name, cost: maxCost };
-    });
-
-    costs.sort((a, b) => b.cost - a.cost);
-    const highest = costs[0].cost;
-    const topPlayers = costs.filter((c) => c.cost === highest);
-    if (topPlayers.length === 1) {
-      io.to(this.roomId).emit("gameEnded", { winner: topPlayers[0].name });
-    } else {
-      io.to(this.roomId).emit("gameEnded", { winner: "引き分け" });
-    }
-  }
-
   nextTurn() {
     this.currentTurn++;
     const nextPlayerId = this.getCurrentPlayerId();
@@ -564,6 +404,8 @@ class GameManager {
     }
   }
 }
+
+Object.assign(GameManager.prototype, effects);
 
 module.exports = GameManager;
 module.exports.CARD_LIST = CARD_LIST;

--- a/backend/game/cards.js
+++ b/backend/game/cards.js
@@ -1,0 +1,16 @@
+const CARD_LIST = [
+  { id: 1, name: "兵士", enName: "soldier", cost: 1, count: 5 },
+  { id: 2, name: "道化", enName: "clown", cost: 2, count: 2 },
+  { id: 3, name: "騎士", enName: "knight", cost: 3, count: 2 },
+  { id: 4, name: "僧侶", enName: "monk", cost: 4, count: 2 },
+  { id: 5, name: "魔術師", enName: "sorcerer", cost: 5, count: 2 },
+  { id: 6, name: "将軍", enName: "general", cost: 6, count: 1 },
+  { id: 7, name: "大臣", enName: "minister", cost: 7, count: 1 },
+  { id: 8, name: "姫", enName: "princess", cost: 8, count: 1 },
+  { id: 9, name: "姫(眼鏡)", enName: "princess_glasses", cost: 8, count: 1 },
+  { id: 10, name: "伯爵夫人", enName: "countess", cost: 8, count: 1 },
+  { id: 11, name: "女侯爵", enName: "marchioness", cost: 7, count: 1 },
+  { id: 12, name: "姫(爆弾)", enName: "princess_bomb", cost: 8, count: 1 },
+];
+
+module.exports = CARD_LIST;

--- a/backend/game/effects.js
+++ b/backend/game/effects.js
@@ -1,0 +1,155 @@
+function checkMinisterElimination(playerId, io) {
+  const player = this.players[playerId];
+  if (!player || player.isEliminated) return false;
+
+  const ministerIndex = player.hand.findIndex((c) => c.id === 7);
+  if (ministerIndex === -1) return false;
+
+  const total = player.hand.reduce((sum, c) => sum + c.cost, 0);
+  if (total >= 12) {
+    player.isEliminated = true;
+    player.hasDrawnCard = false;
+    console.log(`${player.name} は大臣の効果で脱落しました。`);
+
+    this.emitToRoom(io, "playerEliminated", {
+      playerId: playerId,
+      name: player.name,
+    });
+
+    // 大臣のカードを捨て札に移動
+    const ministerCard = player.hand.splice(ministerIndex, 1)[0];
+    this.playedCards.push({ player: player.name, card: ministerCard });
+    this.emitToRoom(io, "cardPlayed", {
+      playerId: playerId,
+      player: player.name,
+      card: ministerCard,
+      playedCards: this.playedCards,
+    });
+
+    const revived = this.checkPrincessGlassesRevival(playerId, io);
+
+    if (!revived) {
+      // 脱落したままなら残りの手札も捨て札へ
+      while (player.hand.length) {
+        const discarded = player.hand.pop();
+        this.playedCards.push({ player: player.name, card: discarded });
+        this.emitToRoom(io, "cardPlayed", {
+          playerId: playerId,
+          player: player.name,
+          card: discarded,
+          playedCards: this.playedCards,
+        });
+      }
+
+      const alive = this.getAlivePlayers();
+      if (alive.length === 1) {
+        this.emitToRoom(io, "gameEnded", { winner: alive[0].name });
+      }
+    }
+
+    return true;
+  }
+  return false;
+}
+
+function checkPrincessElimination(playerId, discardedCard, io) {
+  const player = this.players[playerId];
+  if (!player || player.isEliminated) return;
+
+  if (discardedCard && discardedCard.id === 8) {
+    player.isEliminated = true;
+    console.log(`${player.name} は姫を捨てたため脱落しました。`);
+    const revived = this.checkPrincessGlassesRevival(playerId, io);
+    if (!revived) {
+      this.emitToRoom(io, "playerEliminated", {
+        playerId: playerId,
+        name: player.name,
+      });
+      const alive = this.getAlivePlayers();
+      if (alive.length === 1) {
+        this.emitToRoom(io, "gameEnded", { winner: alive[0].name });
+      }
+    }
+  }
+}
+
+function checkPrincessGlassesRevival(playerId, io) {
+  const player = this.players[playerId];
+  if (!player || !player.isEliminated) return false;
+  const cardIndex = player.hand.findIndex((c) => c.id === 9);
+  if (cardIndex === -1) return false;
+  if (!this.deck.length) return false;
+
+  const discarded = player.hand.splice(cardIndex, 1)[0];
+  this.playedCards.push({ player: player.name, card: discarded });
+  this.emitToRoom(io, "cardPlayed", {
+    playerId: playerId,
+    player: player.name,
+    card: discarded,
+    playedCards: this.playedCards,
+  });
+
+  const newCard = this.deck.pop();
+
+  player.hand.push(newCard);
+  if (this.deck.length === 0) {
+    this.handleCountessElimination(io);
+  }
+  player.isEliminated = false;
+
+  console.log(`${player.name} は姫(眼鏡)の効果で復活しました。`);
+  this.emitToPlayer(io, playerId, "cardDrawn", newCard);
+  this.emitToRoom(io, "playerRevived", {
+    playerId: playerId,
+    name: player.name,
+  });
+  this.emitToRoom(io, "deckCount", { deckCount: this.deck.length });
+  return true;
+}
+
+function handleCountessElimination(io) {
+  Object.keys(this.players).forEach((pid) => {
+    const p = this.players[pid];
+    if (!p.isEliminated && p.hand.some((c) => c.id === 10)) {
+      p.isEliminated = true;
+      console.log(`${p.name} は伯爵夫人を持ったまま山札が尽きたため脱落しました。`);
+      const revived = this.checkPrincessGlassesRevival(pid, io);
+      if (!revived) {
+        this.emitToRoom(io, "playerEliminated", { playerId: pid, name: p.name });
+      }
+    }
+  });
+  const alive = this.getAlivePlayers();
+  if (alive.length === 1) {
+    this.emitToRoom(io, "gameEnded", { winner: alive[0].name });
+  } else {
+    this.determineWinnerByHandCost(io);
+  }
+}
+
+function determineWinnerByHandCost(io) {
+  const alive = this.getAlivePlayers();
+  if (alive.length === 0) return;
+
+  const costs = alive.map((p) => {
+    const maxCost = p.hand.reduce((max, c) => (c.cost > max ? c.cost : max), 0);
+    return { name: p.name, cost: maxCost };
+  });
+
+  costs.sort((a, b) => b.cost - a.cost);
+  const highest = costs[0].cost;
+  const topPlayers = costs.filter((c) => c.cost === highest);
+  if (topPlayers.length === 1) {
+    this.emitToRoom(io, "gameEnded", { winner: topPlayers[0].name });
+  } else {
+    this.emitToRoom(io, "gameEnded", { winner: "引き分け" });
+  }
+}
+
+module.exports = {
+  checkMinisterElimination,
+  checkPrincessElimination,
+  checkPrincessGlassesRevival,
+  handleCountessElimination,
+  determineWinnerByHandCost,
+};


### PR DESCRIPTION
## Summary
- move card definitions to `cards.js`
- extract elimination and revival helpers into `effects.js`
- load helpers in `GameManager` and attach them to the class prototype

## Testing
- `node --test backend/test/GameManager.test.js backend/test/countess.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689f4af04818832fab86c8cfcc8f694a