### PR TITLE
feat: separate room creation and join with game master start

### DIFF
--- a/backend/game/GameManager.js
+++ b/backend/game/GameManager.js
@@ -12,6 +12,7 @@ class GameManager {
     this.currentTurn = 0;
     this.playedCards = [];
     this.gameStarted = false;
+    this.gameMasterId = null;
   }
 
   emitToRoom(io, event, data) {

--- a/backend/index.js
+++ b/backend/index.js
@@ -53,10 +53,13 @@ io.on("connection", (socket) => {
   console.log("A user connected:", socket.id);
 // if room is not exist, create new room. else, enter existing room.
   socket.on("createRoom", async ({ roomId, name, playerId }) => {
-    if (!games[roomId]) {
-      games[roomId] = new GameManager(roomId);
-      console.log("Room created:", roomId);
+    if (games[roomId]) {
+      // Room already exists, treat as join
+      socket.emit("errorMessage", "Room already exists");
+      return;
     }
+    games[roomId] = new GameManager(roomId);
+    console.log("Room created:", roomId);
     const game = games[roomId];
 
     // Reconnect if playerId exists
@@ -86,6 +89,7 @@ io.on("connection", (socket) => {
 
     const success = game.addPlayer(socket.id, name);
     if (success) {
+      game.gameMasterId = socket.id;
       socket.join(roomId);
       const tmp = socket.id; //後で消す
       const roomSockets = await io.in(roomId).fetchSockets();
@@ -101,34 +105,92 @@ io.on("connection", (socket) => {
           isProtected: p.isProtected,
           ishasDrawnCard: p.ishasDrawnCard,
         })),
+        gameMasterId: game.gameMasterId,
+      });
+    }
+  });
+
+  socket.on("joinRoom", async ({ roomId, name, playerId }) => {
+    const game = games[roomId];
+    if (!game) {
+      socket.emit("errorMessage", "Room not found");
+      return;
+    }
+
+    // Reconnect if playerId exists
+    if (playerId && game.players[playerId]) {
+      const oldPlayer = game.players[playerId];
+      delete game.players[playerId];
+      const idx = game.turnOrder.indexOf(playerId);
+      if (idx !== -1) {
+        game.turnOrder[idx] = socket.id;
+      }
+      oldPlayer.id = socket.id;
+      game.players[socket.id] = oldPlayer;
+      if (game.gameMasterId === playerId) {
+        game.gameMasterId = socket.id;
+      }
+      socket.join(roomId);
+      socket.emit("playerId", socket.id);
+      socket.emit("rejoinSuccess");
+      io.to(roomId).emit("roomUpdate", {
+        players: Object.values(game.players).map((p) => ({
+          id: p.id,
+          name: p.name,
+          isEliminated: p.isEliminated,
+          isProtected: p.isProtected,
+          ishasDrawnCard: p.ishasDrawnCard,
+        })),
+        gameMasterId: game.gameMasterId,
+      });
+      return;
+    }
+
+    const success = game.addPlayer(socket.id, name);
+    if (success) {
+      socket.join(roomId);
+      const tmp = socket.id; //後で消す
+      const roomSockets = await io.in(roomId).fetchSockets();
+      const userList = roomSockets.map((s) => s.id);
+      console.log(`Room ${roomId} に現在joinしているユーザー一覧:`, userList);
+      console.log(`追加したプレイヤーは:`, game.players[tmp].id);
+      socket.emit("playerId", socket.id);
+      io.to(roomId).emit("roomUpdate", {
+        players: Object.values(game.players).map((p) => ({
+          id: p.id,
+          name: p.name,
+          isEliminated: p.isEliminated,
+          isProtected: p.isProtected,
+          ishasDrawnCard: p.ishasDrawnCard,
+        })),
+        gameMasterId: game.gameMasterId,
       });
     }
   });
 
   socket.on("startGame", ({ roomId }) => {
     const game = games[roomId];
+    if (!game || socket.id !== game.gameMasterId) return;
     logPlayerHands(game);
-    if (game) {
-      game.startGame();
-      // 各プレイヤーに自分の手札を送信
-      Object.keys(game.players).forEach(playerId => {
+    game.startGame();
+    // 各プレイヤーに自分の手札を送信
+    Object.keys(game.players).forEach(playerId => {
       const player = game.players[playerId];
       io.to(playerId).emit("initialHand", player.hand);
-      });
+    });
 
-      // 全員にゲーム開始通知
-      const currentPlayerId = game.getCurrentPlayerId();
-      io.to(roomId).emit("gameStarted", {
-        players: Object.values(game.players).map((p) => ({
-          id: p.id,
-          name: p.name,
-          handCount: p.hand.length,
-        })),
-        currentPlayer: game.players[currentPlayerId].name,
-        deckCount: game.deck.length,
-      });
-        console.log("Game Start:", game.players[currentPlayerId].name);
-    }
+    // 全員にゲーム開始通知
+    const currentPlayerId = game.getCurrentPlayerId();
+    io.to(roomId).emit("gameStarted", {
+      players: Object.values(game.players).map((p) => ({
+        id: p.id,
+        name: p.name,
+        handCount: p.hand.length,
+      })),
+      currentPlayer: game.players[currentPlayerId].name,
+      deckCount: game.deck.length,
+    });
+    console.log("Game Start:", game.players[currentPlayerId].name);
   });
 
   socket.on("drawCard", ({ roomId }) => {

--- a/tests/clown.spec.ts
+++ b/tests/clown.spec.ts
@@ -23,18 +23,18 @@ test('first player draws a clown and sees opponent\'s hand', async ({ browser })
   // Player1 creates room
   await page1.getByRole('textbox', { name: 'ニックネーム：' }).fill('alice');
   await page1.getByRole('textbox', { name: 'ルームID：' }).fill(roomName);
-  await page1.getByRole('button', { name: '部屋を作る / 入室' }).click();
+  await page1.getByRole('button', { name: '部屋を作る' }).click();
 　await sleep(1000);
 
   // Player2 joins room
   await page2.getByRole('textbox', { name: 'ニックネーム：' }).fill('bob');
   await page2.getByRole('textbox', { name: 'ルームID：' }).fill(roomName);
-  await page2.getByRole('button', { name: '部屋を作る / 入室' }).click();
+  await page2.getByRole('button', { name: '入室' }).click();
 　await sleep(1000);
 
   // Start game
   await page1.getByRole('button', { name: 'ゲーム開始' }).click();
-  await page2.getByRole('button', { name: 'ゲーム開始' }).click();
+  await sleep(1000);
 
   　// ユーザIDの取得
   const players = await playersPromise;

--- a/tests/knight.spec.ts
+++ b/tests/knight.spec.ts
@@ -24,20 +24,20 @@ test('first player draws a knight but no one is eliminated', async ({ browser })
   // Player1 creates room
   await page1.getByRole('textbox', { name: 'ニックネーム：' }).fill('alice');
   await page1.getByRole('textbox', { name: 'ルームID：' }).fill(roomName);
-  await page1.getByRole('button', { name: '部屋を作る / 入室' }).click();
+  await page1.getByRole('button', { name: '部屋を作る' }).click();
 　await sleep(2000);
 
   // Player2 joins room
   await page2.getByRole('textbox', { name: 'ニックネーム：' }).fill('bob');
   await page2.getByRole('textbox', { name: 'ルームID：' }).fill(roomName);
-  await page2.getByRole('button', { name: '部屋を作る / 入室' }).click();
+  await page2.getByRole('button', { name: '入室' }).click();
 　await sleep(2000);
 
 
 
   // Start game
   await page1.getByRole('button', { name: 'ゲーム開始' }).click();
-  await page2.getByRole('button', { name: 'ゲーム開始' }).click();
+  await sleep(2000);
 
 
   const players = await playersPromise;

--- a/tests/marichioness.spec.ts
+++ b/tests/marichioness.spec.ts
@@ -23,18 +23,18 @@ test('player forced to play marchioness when hand cost is 12 or more', async ({ 
   // Player1 creates room
   await page1.getByRole('textbox', { name: 'ニックネーム：' }).fill('alice');
   await page1.getByRole('textbox', { name: 'ルームID：' }).fill(roomName);
-  await page1.getByRole('button', { name: '部屋を作る / 入室' }).click();
+  await page1.getByRole('button', { name: '部屋を作る' }).click();
   await sleep(1000);
 
   // Player2 joins room
   await page2.getByRole('textbox', { name: 'ニックネーム：' }).fill('bob');
   await page2.getByRole('textbox', { name: 'ルームID：' }).fill(roomName);
-  await page2.getByRole('button', { name: '部屋を作る / 入室' }).click();
+  await page2.getByRole('button', { name: '入室' }).click();
   await sleep(1000);
 
   // Start game
   await page1.getByRole('button', { name: 'ゲーム開始' }).click();
-  await page2.getByRole('button', { name: 'ゲーム開始' }).click();
+  await sleep(1000);
 
   const players = await playersPromise;
   const aliceId = players.find(p => p.name === 'alice').id;
@@ -96,18 +96,18 @@ test('player discard  when hand is  marchioness & minister', async ({ browser })
   // Player1 creates room
   await page1.getByRole('textbox', { name: 'ニックネーム：' }).fill('alice');
   await page1.getByRole('textbox', { name: 'ルームID：' }).fill(roomName);
-  await page1.getByRole('button', { name: '部屋を作る / 入室' }).click();
+  await page1.getByRole('button', { name: '部屋を作る' }).click();
   await sleep(1000);
 
   // Player2 joins room
   await page2.getByRole('textbox', { name: 'ニックネーム：' }).fill('bob');
   await page2.getByRole('textbox', { name: 'ルームID：' }).fill(roomName);
-  await page2.getByRole('button', { name: '部屋を作る / 入室' }).click();
+  await page2.getByRole('button', { name: '入室' }).click();
   await sleep(1000);
 
   // Start game
   await page1.getByRole('button', { name: 'ゲーム開始' }).click();
-  await page2.getByRole('button', { name: 'ゲーム開始' }).click();
+  await sleep(1000);
 
   const players = await playersPromise;
   const aliceId = players.find(p => p.name === 'alice').id;

--- a/tests/princess.spec.ts
+++ b/tests/princess.spec.ts
@@ -26,18 +26,18 @@ test('first player draws a soldier and eliminates opponent', async ({ browser })
   // Player1 creates room
   await page1.getByRole('textbox', { name: 'ニックネーム：' }).fill('alice');
   await page1.getByRole('textbox', { name: 'ルームID：' }).fill(roomName);
-  await page1.getByRole('button', { name: '部屋を作る / 入室' }).click();
+  await page1.getByRole('button', { name: '部屋を作る' }).click();
 　await sleep(2000);
 
   // Player2 joins room
   await page2.getByRole('textbox', { name: 'ニックネーム：' }).fill('bob');
   await page2.getByRole('textbox', { name: 'ルームID：' }).fill(roomName);
-  await page2.getByRole('button', { name: '部屋を作る / 入室' }).click();
+  await page2.getByRole('button', { name: '入室' }).click();
 　await sleep(2000);
 
   // Start game
   await page1.getByRole('button', { name: 'ゲーム開始' }).click();
-  await page2.getByRole('button', { name: 'ゲーム開始' }).click();
+  await sleep(2000);
 
 
   const players = await playersPromise;

--- a/tests/princess_bomb.spec.ts
+++ b/tests/princess_bomb.spec.ts
@@ -24,18 +24,18 @@ test('player discard  by playing princess_bomb and bob win.', async ({ browser }
   // Player1 creates room
   await page1.getByRole('textbox', { name: 'ニックネーム：' }).fill('alice');
   await page1.getByRole('textbox', { name: 'ルームID：' }).fill(roomName);
-  await page1.getByRole('button', { name: '部屋を作る / 入室' }).click();
+  await page1.getByRole('button', { name: '部屋を作る' }).click();
   await sleep(1000);
 
   // Player2 joins room
   await page2.getByRole('textbox', { name: 'ニックネーム：' }).fill('bob');
   await page2.getByRole('textbox', { name: 'ルームID：' }).fill(roomName);
-  await page2.getByRole('button', { name: '部屋を作る / 入室' }).click();
+  await page2.getByRole('button', { name: '入室' }).click();
   await sleep(1000);
 
   // Start game
   await page1.getByRole('button', { name: 'ゲーム開始' }).click();
-  await page2.getByRole('button', { name: 'ゲーム開始' }).click();
+  await sleep(1000);
 
   const players = await playersPromise;
   const aliceId = players.find(p => p.name === 'alice').id;
@@ -89,25 +89,24 @@ test('3 player play, player1 plays monk, player2 plays princess_bomb, player3 wi
   // Player1 creates room
   await page1.getByRole('textbox', { name: 'ニックネーム：' }).fill('alice');
   await page1.getByRole('textbox', { name: 'ルームID：' }).fill(roomName);
-  await page1.getByRole('button', { name: '部屋を作る / 入室' }).click();
+  await page1.getByRole('button', { name: '部屋を作る' }).click();
   await sleep(1000);
 
   // Player2 joins room
   await page2.getByRole('textbox', { name: 'ニックネーム：' }).fill('bob');
   await page2.getByRole('textbox', { name: 'ルームID：' }).fill(roomName);
-  await page2.getByRole('button', { name: '部屋を作る / 入室' }).click();
+  await page2.getByRole('button', { name: '入室' }).click();
   await sleep(1000);
 
 　// Player3 joins room
   await page3.getByRole('textbox', { name: 'ニックネーム：' }).fill('charlie');
   await page3.getByRole('textbox', { name: 'ルームID：' }).fill(roomName);
-  await page3.getByRole('button', { name: '部屋を作る / 入室' }).click();
+  await page3.getByRole('button', { name: '入室' }).click();
   await sleep(1000);
 
   // Start game
   await page1.getByRole('button', { name: 'ゲーム開始' }).click();
-  await page2.getByRole('button', { name: 'ゲーム開始' }).click();
-  await page3.getByRole('button', { name: 'ゲーム開始' }).click();
+  await sleep(1000);
 
   const players = await playersPromise;
   const aliceId = players.find(p => p.name === 'alice').id;

--- a/tests/soldier.spec.ts
+++ b/tests/soldier.spec.ts
@@ -29,20 +29,20 @@ test('first player draws a soldier and eliminates opponent', async ({ browser })
   // Player1 creates room
   await page1.getByRole('textbox', { name: 'ニックネーム：' }).fill('alice');
   await page1.getByRole('textbox', { name: 'ルームID：' }).fill(roomName);
-  await page1.getByRole('button', { name: '部屋を作る / 入室' }).click();
+  await page1.getByRole('button', { name: '部屋を作る' }).click();
 　await sleep(2000);
 
   // Player2 joins room
   await page2.getByRole('textbox', { name: 'ニックネーム：' }).fill('bob');
   await page2.getByRole('textbox', { name: 'ルームID：' }).fill(roomName);
-  await page2.getByRole('button', { name: '部屋を作る / 入室' }).click();
+  await page2.getByRole('button', { name: '入室' }).click();
 　await sleep(2000);
 
 
 
   // Start game
   await page1.getByRole('button', { name: 'ゲーム開始' }).click();
-  await page2.getByRole('button', { name: 'ゲーム開始' }).click();
+  await sleep(2000);
 
 
   const players = await playersPromise;

--- a/tests/sorcerer.spec.ts
+++ b/tests/sorcerer.spec.ts
@@ -29,20 +29,20 @@ test('first player draws a magician and eliminates opponent holding princess', a
   // Player1 creates room
   await page1.getByRole('textbox', { name: 'ニックネーム：' }).fill('alice');
   await page1.getByRole('textbox', { name: 'ルームID：' }).fill(roomName);
-  await page1.getByRole('button', { name: '部屋を作る / 入室' }).click();
+  await page1.getByRole('button', { name: '部屋を作る' }).click();
 　await sleep(2000);
 
   // Player2 joins room
   await page2.getByRole('textbox', { name: 'ニックネーム：' }).fill('bob');
   await page2.getByRole('textbox', { name: 'ルームID：' }).fill(roomName);
-  await page2.getByRole('button', { name: '部屋を作る / 入室' }).click();
+  await page2.getByRole('button', { name: '入室' }).click();
 　await sleep(2000);
 
 
 
   // Start game
   await page1.getByRole('button', { name: 'ゲーム開始' }).click();
-  await page2.getByRole('button', { name: 'ゲーム開始' }).click();
+  await sleep(2000);
 
 
   const players = await playersPromise;
@@ -101,20 +101,20 @@ test('first player draws a magician and use.  second player do not discart count
   // Player1 creates room
   await page1.getByRole('textbox', { name: 'ニックネーム：' }).fill('alice');
   await page1.getByRole('textbox', { name: 'ルームID：' }).fill(roomName);
-  await page1.getByRole('button', { name: '部屋を作る / 入室' }).click();
+  await page1.getByRole('button', { name: '部屋を作る' }).click();
 　await sleep(2000);
 
   // Player2 joins room
   await page2.getByRole('textbox', { name: 'ニックネーム：' }).fill('bob');
   await page2.getByRole('textbox', { name: 'ルームID：' }).fill(roomName);
-  await page2.getByRole('button', { name: '部屋を作る / 入室' }).click();
+  await page2.getByRole('button', { name: '入室' }).click();
 　await sleep(2000);
 
 
 
   // Start game
   await page1.getByRole('button', { name: 'ゲーム開始' }).click();
-  await page2.getByRole('button', { name: 'ゲーム開始' }).click();
+  await sleep(2000);
 
 
   const players = await playersPromise;


### PR DESCRIPTION
## Summary
- split lobby actions into distinct create and join buttons
- track a room's game master and allow only them to start games
- update tests for new lobby flow

## Testing
- `npx playwright test` *(fails: browserType.launch: Executable doesn't exist)*
- `npx playwright install chromium firefox webkit` *(fails: Download failed 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b2c06e9b38832f84d8793948ecff1d