### PR TITLE
Enable environment-configurable deployment settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+## Deployment
+
+This project contains a Node.js backend (`/backend`) and a React frontend
+(`/frontend`).
+
+When deploying to an online server, configure the following environment
+variables so that the frontend can reach the backend and the backend accepts
+requests from your deployment domain.
+
+### Backend
+
+- `PORT`: Port number the server should listen on. Defaults to `4000`.
+- `CLIENT_ORIGIN`: URL of the frontend that is allowed to access the backend.
+
+### Frontend
+
+- `REACT_APP_BACKEND_URL`: URL of the backend server. Defaults to
+  `http://localhost:4000` for local development.
+
+Example:
+
+```bash
+# Backend
+CLIENT_ORIGIN=https://your-frontend.example.com PORT=80 node backend/index.js
+
+# Frontend
+REACT_APP_BACKEND_URL=https://your-backend.example.com npm run build
+```
+
+These variables make the application configurable and ready for deployment on
+remote servers.

--- a/backend/index.js
+++ b/backend/index.js
@@ -7,10 +7,22 @@ const { CARD_LIST } = GameManager;
 
 const app = express();
 app.use(express.json());
+
+// Determine the allowed CORS origin from environment or default to localhost
+const allowedOrigin = process.env.CLIENT_ORIGIN || "http://localhost:3000";
+
+// Enable CORS for Express routes so that requests from remote frontends work
+app.use(
+  cors({
+    origin: allowedOrigin,
+    methods: ["GET", "POST"],
+  })
+);
+
 const server = http.createServer(app);
 const io = new Server(server, {
   cors: {
-    origin: "http://localhost:3000",
+    origin: allowedOrigin,
     methods: ["GET", "POST"],
   },
 });
@@ -299,7 +311,8 @@ function logPlayerHands(game) {
   console.log("=========================================");
 }
 
-const PORT = 4000;
+// Use the PORT environment variable if provided (e.g., in cloud deployments)
+const PORT = process.env.PORT || 4000;
 server.listen(PORT, () => {
-  console.log(`Server listening on http://localhost:${PORT}`);
+  console.log(`Server listening on port ${PORT}`);
 });

--- a/frontend/src/socket.ts
+++ b/frontend/src/socket.ts
@@ -1,5 +1,10 @@
 import { io } from "socket.io-client";
 
-const socket = io("http://localhost:4000");
+// Allow configuring the backend URL via environment variable for deployment
+// React only exposes env variables prefixed with REACT_APP_
+const backendUrl =
+  process.env.REACT_APP_BACKEND_URL || "http://localhost:4000";
+
+const socket = io(backendUrl);
 
 export default socket;


### PR DESCRIPTION
## Summary
- allow configuring backend CORS origin and port through environment variables
- make frontend socket connection use `REACT_APP_BACKEND_URL`
- document deployment environment variables in README

## Testing
- `cd backend && npm test`
- `cd frontend && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b34695661c832f88856bb6eb02b3bc